### PR TITLE
Fix nextjs build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "artisan-marketplace",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "type": "module",
     "start": "next start",
     "lint": "next lint"
   },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,0 @@
-// postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,6 +1,6 @@
 // In src/app/account/page.tsx
 import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { authOptions } from "@/lib/auth";
 import { redirect } from 'next/navigation';
 
 export default async function AccountPage() {

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,6 +1,6 @@
 // In src/app/admin/dashboard/page.tsx
 import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { authOptions } from "@/lib/auth";
 import AdminDashboardClient from '@/components/admin/AdminDashboardClient'; // Import the UI component
 
 export default async function AdminDashboardPage() {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,33 +1,5 @@
-import NextAuth, { AuthOptions } from "next-auth";
-import CredentialsProvider from "next-auth/providers/credentials";
-
-// Keep authOptions private, do NOT export it
-const authOptions: AuthOptions = {
-  providers: [
-    CredentialsProvider({
-      name: "Credentials",
-      credentials: {
-        email: { label: "Email", type: "email" },
-        password: { label: "Password", type: "password" },
-      },
-      async authorize(credentials) {
-        if (
-          credentials?.email === "test@example.com" &&
-          credentials?.password === "1234"
-        ) {
-          return { id: "1", name: "Test User", email: "test@example.com" }; // id must be string
-        }
-        return null;
-      },
-    }),
-  ],
-  session: {
-    strategy: "jwt",
-  },
-  pages: {
-    signIn: "/login",
-  },
-};
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 // Only export GET and POST for App Router
 const handler = NextAuth(authOptions);

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { useCart, CartItem } from '@/context/CartContext'
+import { useCart } from '@/context/CartContext'
+import type { CartItem } from '@/context/CartContext'
 
 export default function Checkout() {
   // CORRECTED: The context now provides `items`, not `cartItems`.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,17 +3,20 @@ import './globals.css';
 import { Header } from '@/components/Layout/Header';
 import Footer from '@/components/Layout/Footer';
 import AuthProvider from './providers/AuthProvider';
+import { CartProvider } from '@/context/CartContext';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <AuthProvider> {/* This is the new provider */}
-          <div className="min-h-screen flex flex-col">
-            <Header />
-            <main className="flex-grow">{children}</main>
-            <Footer />
-          </div>
+        <AuthProvider>
+          <CartProvider>
+            <div className="min-h-screen flex flex-col">
+              <Header />
+              <main className="flex-grow">{children}</main>
+              <Footer />
+            </div>
+          </CartProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useState, ReactNode } from 'react'
 
-interface CartItem {
+export interface CartItem {
   id: number
   name: string
   price: number

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
-// In tailwind.config.js
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+// In tailwind.config.ts
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -26,3 +27,5 @@ module.exports = {
   },
   plugins: [],
 };
+
+export default config;


### PR DESCRIPTION
Unify `authOptions` imports and resolve ESM/CJS configuration issues to enable a successful Next.js production build.

The build was failing due to `authOptions` not being exported from the NextAuth API route, which was then imported by other pages. This PR refactors `authOptions` into a shared `src/lib/auth.ts` file, making it a single source of truth. Additionally, several ESM/CommonJS configuration mismatches (e.g., `package.json` type, `postcss.config.js`, `tailwind.config.ts`) were causing build warnings and errors, which are now resolved by aligning them with ESM. Finally, `CartContext` related type and prerender errors were addressed by exporting `CartItem` and wrapping the `RootLayout` with `CartProvider`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a372e35-e049-46db-99d3-a97fdd600b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a372e35-e049-46db-99d3-a97fdd600b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

